### PR TITLE
App Engine Push-to-Deploy Fix

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -2,7 +2,7 @@ application: c3po-bot
 version: 1
 runtime: python27
 api_version: 1
-threadsafe: yes
+threadsafe: false
 
 handlers:
 - url: .*


### PR DESCRIPTION
App Engine should be able to detect changes in GitHub and
automatically deploy. For this to happen, threadsafe must be false.