### PR TITLE
Revert "App Engine Push-to-Deploy Fix"

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -2,7 +2,7 @@ application: c3po-bot
 version: 1
 runtime: python27
 api_version: 1
-threadsafe: false
+threadsafe: yes
 
 handlers:
 - url: .*


### PR DESCRIPTION
Reverts rhefner1/c3po#2

AE push-to-deploy was discontinued in January. Need to find a way to make Travis deploy it.