### PR TITLE
Skip App Engine SDK when Deploying

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -13,3 +13,12 @@ libraries:
   version: "2.6"
 - name: markupsafe
   version: "0.15"
+
+skip_files:
+- ^(.*/)?#.*#$
+- ^(.*/)?.*~$
+- ^(.*/)?.*\.py[co]$
+- ^(.*/)?.*/RCS/.*$
+- ^(.*/)?\..*$
+- appengine_sdk.zip
+- (google_appengine/.*)|


### PR DESCRIPTION
The test runner downloads the App Engine SDK in the ci/ directory.
Adding regex to ensure that the SDK isn't uploaded as part of the
deployment.