### PR TITLE
All requests should be HTTPS

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -7,6 +7,7 @@ threadsafe: yes
 handlers:
 - url: .*
   script: c3po.main.app
+  secure: always
 
 libraries:
 - name: jinja2


### PR DESCRIPTION
This setting doesn't allow any connections to be unsecured HTTP.
Since we're dealing with private group conversations, encryption
should be available.