### PR TITLE
Change skip file regex

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -21,4 +21,4 @@ skip_files:
 - ^(.*/)?.*/RCS/.*$
 - ^(.*/)?\..*$
 - appengine_sdk.zip
-- (google_appengine/.*)|
+- ^(.*/)?.*google_appengine/.*$


### PR DESCRIPTION
Apparently, putting the pipe at the end caused some unintended effects
for the operation of App Engine. Removing those.

Closes #8