### PR TITLE
Enable App Engine Deployment in Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,9 @@
 language: python
 install: ./ci/install_deps.sh
 script: ./ci/run_tests.sh
+after_success: ./ci/deploy.sh
 after_script: ./ci/cleanup.sh
+
+env:
+  global:
+    secure: "Q3+vjktnBh42WB25m0fKikpJrll0I/nQXhplhhMZFe/s2v3/MrZPGC6aH/sOw7qND7a2kszK9AsQqpS4Rfs0cS2ArBCcY7/362SluTh6T75XbJfjuSr3bbNJK8f2Lu6vBYHo45+xGq8jhlxQgL0rl+yYx6jGYtCoYwvENdajeJKEJJIeGkcvh7LwB2s9agKgkhEGWoVX3pp5tXYSVIsLdZOnySeaB1WDN6dDn8wynut7I9sdH6hPIVGEdZvhKzAj6e+c9UDEYp56qV3QHo06vy3AUWrXJDuL+yEJ/wnHQG3V1UhNURcnq7BWnXtmGH2TyJ7rYSrK9TA7guNgOWL3dhHvcRkBgR2IFxiSwuYxzOaTBqtaGziDT5oNCHK5olWmZdPPHmOumXDtaNHG7kLY/swFJyJz26dqDeWrTVWo57JV7FbYbnLiL83QH6W5RvpPmc9R/vaI+aTL3j8CGlc30dPIQQ8GkPsQUTFm+H7t4nN0IHdH2LRkIc0Zjs3go5uIBlXJ6wOpaBeujVrnX8ub4NCbfrGCJaUi7EJiP1s46C7wYLV2I40OhXgW/nHMmKeZviTxdeMLOg/Ugbf/PPmbMF9bhwTTt3seyMEEdPaG1sZulPbg5G7kjLRYbobvN3J2t+IIkAHCLbAh00/yrlhkJqexzanudOHewVyY0V6ag/Y="

--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,8 +1,11 @@
 #!/usr/bin/env bash
 
-echo -e "\n\n### Installing pip requirements to lib directory"
-pip install -t lib -r requirements.txt
+if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == false ]]
+then
+    echo -e "\n\n### Installing pip requirements to lib directory"
+    pip install -t lib -r requirements.txt
 
-echo -e "\n\n### Deploying to App Engine"
-cd ./ci/google_appengine
-python appcfg.py update --oauth2_refresh_token=$AE_OAUTH_REFRESH ../../
+    echo -e "\n\n### Deploying to App Engine"
+    cd ./ci/google_appengine
+    python appcfg.py update --oauth2_refresh_token=$AE_OAUTH_REFRESH ../../
+fi


### PR DESCRIPTION
I realized that Travis is running tests when pull requests are
merged and there is an env variable $TRAVIS_BRANCH that we can check.
Now, if the branch == "master", then the deployment is triggered.

The App Engine refresh token is also registered in the Travis env
variables.