### PR TITLE
Add GroupMe Bot API

### DIFF
--- a/c3po/main.py
+++ b/c3po/main.py
@@ -6,7 +6,7 @@ from flask import abort, Flask, request
 
 from c3po.message import Message
 
-SUCCESS = ("", 200)
+SUCCESS = ('', 200)
 
 APP = Flask(__name__)
 APP.config['DEBUG'] = True
@@ -30,7 +30,8 @@ def message():
 
     try:
         msg.process_message()
-    except ValueError:
+    except ValueError as error:
+        logging.debug("Failed processing message because: %s", error.message)
         abort(400)
 
     return SUCCESS
@@ -39,7 +40,7 @@ def message():
 @APP.route('/test')
 def test():
     """Says hello!"""
-    return "Hello!"
+    return 'Hello!'
 
 
 @APP.errorhandler(404)

--- a/c3po/responders.py
+++ b/c3po/responders.py
@@ -1,6 +1,7 @@
 """Contains the definitions for the responders. Each one of these functions is
 mapped in the message module."""
 
+
 def hello(message):
     """Says hello!"""
-    return "Greetings. I am C-3PO, human cyborg relations."
+    return 'Greetings. I am C-3PO, human cyborg relations.'

--- a/c3po/settings.py
+++ b/c3po/settings.py
@@ -6,4 +6,4 @@ from google.appengine.ext import ndb
 class Settings(ndb.Model):
     """Models the mapping between group ID and bot ID."""
     group_id = ndb.StringProperty()
-    bod_id = ndb.StringProperty()
+    bot_id = ndb.StringProperty()

--- a/tests/test_message.py
+++ b/tests/test_message.py
@@ -1,13 +1,64 @@
 import unittest
 
-from c3po.message import Message
+import mock
+from google.appengine.api import urlfetch
+
+from c3po import message
+
+GROUP_ID = 'abc'
+NAME = 'Billy'
+TEXT = ''
 
 
 class TestRegex(unittest.TestCase):
     def test_generate_regex(self):
-        regex = "hi"
-        self.assertEqual(Message._generate_regex(regex),
+        regex = 'hi'
+        self.assertEqual(message.Message._generate_regex(regex),
                          r'(\s+)hi($|\s+|\?+|\.+|\!+)')
+
+
+class TestGeneratePostBody(unittest.TestCase):
+    def setUp(self):
+        self.msg = message.Message(GROUP_ID, NAME, TEXT)
+
+    @mock.patch('c3po.message.Message._get_bot_id')
+    def test_generate_api_post_body(self, mock_get_bot_id):
+        mock_get_bot_id.return_value = '123'
+
+        actual_post_body = self.msg._generate_api_post_body('sample')
+        expected_post_body = 'text=sample&bot_id=123'
+
+        self.assertEqual(actual_post_body, expected_post_body)
+
+
+class TestSendResponse(unittest.TestCase):
+    def setUp(self):
+        self.msg = message.Message(GROUP_ID, NAME, TEXT)
+
+    @mock.patch('c3po.message.Message._generate_api_post_body')
+    @mock.patch('google.appengine.api.urlfetch.fetch')
+    def test_send_response(self, mock_urlfetch, mock_gen_api_post_body):
+        mock_gen_api_post_body.return_value = 'text=sample&bot_id=123'
+        mock_urlfetch.return_value.status_code = 202
+
+        self.msg._send_response('sample')
+
+        mock_urlfetch.assert_called_with(
+            url=message.GROUPME_API_ENDPOINT + message.GROUPME_API_PATH,
+            payload='text=sample&bot_id=123',
+            method=urlfetch.POST,
+            headers=message.GROUPME_API_HEADERS
+        )
+
+    @mock.patch('c3po.message.Message._generate_api_post_body')
+    @mock.patch('google.appengine.api.urlfetch.fetch')
+    def test_send_response_500(self, mock_urlfetch, mock_gen_api_post_body):
+        mock_gen_api_post_body.return_value = 'text=sample&bot_id=123'
+        mock_urlfetch.return_value.status_code = 202
+
+        self.msg._send_response('sample')
+
+        self.assertRaises(RuntimeError)
 
 
 if __name__ == '__main__':

--- a/tests/test_responders.py
+++ b/tests/test_responders.py
@@ -1,23 +1,24 @@
-import mock
 import unittest
+
+import mock
 
 from c3po.message import Message
 
-GROUP_ID = "abc"
-NAME = "Billy"
+GROUP_ID = 'abc'
+NAME = 'Billy'
 
 
 class TestHello(unittest.TestCase):
     def setUp(self):
-        self.msg = Message(GROUP_ID, NAME, "")
+        self.msg = Message(GROUP_ID, NAME, '')
 
     @mock.patch('c3po.message.Message._send_response')
     def test_hello(self, mock_send_response):
-        self.msg.text = "c3po hello"
+        self.msg.text = 'c3po hello'
         self.msg.process_message()
 
         mock_send_response.assert_called_with(
-            "Greetings. I am C-3PO, human cyborg relations.")
+            'Greetings. I am C-3PO, human cyborg relations.')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
Tying in the GroupMe Bot API call to message.Message._send_response.
This will post a message to the group associated with the Bot ID.
Note that it is required to have a Settings object in the datastore
that has the association between the group ID (given in the initial
callback) and the bot ID (considered secret).