### PR TITLE
Add Travis build status to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,3 +7,6 @@ Here's what I can do:
  - 
 
 I was lovingly created by [Ryan Hefner](http://r.hefner1.com)
+
+## Travis Status
+![Travis Build Status](https://api.travis-ci.org/rhefner1/c3po.svg)


### PR DESCRIPTION
Add the Travis build status to the README to quickly show whether master is passing tests.