### PR TITLE
Add Pylint to CI

### DIFF
--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -7,3 +7,5 @@ echo "Current PYTHONPATH: ${PYTHONPATH}"
 
 echo -e "\n### Running unit tests"
 python -m unittest discover
+pylint c3po
+pylint tests

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@
 # Note: The `lib` directory is added to `sys.path` by `appengine_config.py`.
 Flask==0.10
 mock
+pylint


### PR DESCRIPTION
Pylint will find common Python errors and PEP8 violations. Adding
this to the CI run_tests to correct those errors before merging.