### PR TITLE
Run unit test and pylint in separate jobs

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,17 @@
 language: python
-install: ./ci/install_deps.sh
-script: ./ci/run_tests.sh
-after_success: ./ci/deploy.sh
-after_script: ./ci/cleanup.sh
 
 env:
   global:
     secure: "Q3+vjktnBh42WB25m0fKikpJrll0I/nQXhplhhMZFe/s2v3/MrZPGC6aH/sOw7qND7a2kszK9AsQqpS4Rfs0cS2ArBCcY7/362SluTh6T75XbJfjuSr3bbNJK8f2Lu6vBYHo45+xGq8jhlxQgL0rl+yYx6jGYtCoYwvENdajeJKEJJIeGkcvh7LwB2s9agKgkhEGWoVX3pp5tXYSVIsLdZOnySeaB1WDN6dDn8wynut7I9sdH6hPIVGEdZvhKzAj6e+c9UDEYp56qV3QHo06vy3AUWrXJDuL+yEJ/wnHQG3V1UhNURcnq7BWnXtmGH2TyJ7rYSrK9TA7guNgOWL3dhHvcRkBgR2IFxiSwuYxzOaTBqtaGziDT5oNCHK5olWmZdPPHmOumXDtaNHG7kLY/swFJyJz26dqDeWrTVWo57JV7FbYbnLiL83QH6W5RvpPmc9R/vaI+aTL3j8CGlc30dPIQQ8GkPsQUTFm+H7t4nN0IHdH2LRkIc0Zjs3go5uIBlXJ6wOpaBeujVrnX8ub4NCbfrGCJaUi7EJiP1s46C7wYLV2I40OhXgW/nHMmKeZviTxdeMLOg/Ugbf/PPmbMF9bhwTTt3seyMEEdPaG1sZulPbg5G7kjLRYbobvN3J2t+IIkAHCLbAh00/yrlhkJqexzanudOHewVyY0V6ag/Y="
+  matrix:
+   - RUN_TESTS=true
+   - RUN_PYLINT=true
+
+install: ./ci/install_deps.sh
+
+script:
+ - ./ci/run_tests.sh
+ - ./ci/run_pylint.sh
+
+after_success: ./ci/deploy.sh
+after_script: ./ci/cleanup.sh

--- a/ci/run_pylint.sh
+++ b/ci/run_pylint.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+if [[ $RUN_PYLINT == true ]]
+then
+    echo -e "### Adding SDK to Python path"
+    export PYTHONPATH="${PYTHONPATH}:$(pwd)/ci/google_appengine"
+    export PYTHONPATH="${PYTHONPATH}:$(pwd)/ci/google_appengine/lib/yaml-3.10"
+    echo "Current PYTHONPATH: ${PYTHONPATH}"
+
+    echo -e "\n### Running pylint"
+    pylint c3po --disable=no-member --disable too-few-public-methods --disable unused-argument
+    pylint tests --disable=no-member --disable too-few-public-methods --disable unused-argument --disable missing-docstring --disable protected-access
+fi

--- a/ci/run_tests.sh
+++ b/ci/run_tests.sh
@@ -1,13 +1,12 @@
 #!/usr/bin/env bash
 
-echo -e "### Adding SDK to Python path"
-export PYTHONPATH="${PYTHONPATH}:$(pwd)/ci/google_appengine"
-export PYTHONPATH="${PYTHONPATH}:$(pwd)/ci/google_appengine/lib/yaml-3.10"
-echo "Current PYTHONPATH: ${PYTHONPATH}"
+if [[ $RUN_TESTS == true ]]
+then
+    echo -e "### Adding SDK to Python path"
+    export PYTHONPATH="${PYTHONPATH}:$(pwd)/ci/google_appengine"
+    export PYTHONPATH="${PYTHONPATH}:$(pwd)/ci/google_appengine/lib/yaml-3.10"
+    echo "Current PYTHONPATH: ${PYTHONPATH}"
 
-echo -e "\n### Running unit tests"
-python -m unittest discover
-
-echo -e "\n### Running pylint"
-pylint c3po --disable=no-member --disable too-few-public-methods --disable unused-argument
-pylint tests --disable=no-member --disable too-few-public-methods --disable unused-argument --disable missing-docstring --disable protected-access
+    echo -e "\n### Running unit tests"
+    python -m unittest discover
+fi


### PR DESCRIPTION
Currently, unit tests and pylint run in the same job. It would be
helpful for these to run in different jobs to get a sense of why
a failure is seen. Also, this allows the two jobs to run concurrently.