### PR TITLE
CI Only Deploy Once

### DIFF
--- a/ci/deploy.sh
+++ b/ci/deploy.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == false ]]
+if [[ $TRAVIS_BRANCH == "master" && $TRAVIS_PULL_REQUEST == false && $RUN_TESTS == true ]]
 then
     echo -e "### Installing pip requirements to lib directory"
     pip install -t lib -r requirements.txt


### PR DESCRIPTION
With the changes in 9f43d95, the CI is deploying on both the unit
test run and the Pylint run. Adding a conditional here to make sure
that the deploy only happens after a successful unit test run.