### PR TITLE
Lowercase the dashed C-3PO identifier

### DIFF
--- a/c3po/message.py
+++ b/c3po/message.py
@@ -4,7 +4,7 @@ import abc
 import logging
 import re
 
-REGEX_MENTIONED = r'(C-3PO|c3po)'
+REGEX_MENTIONED = r'(c-3po|c3po)'
 
 # Regex matching either:
 #   1) beginning of string


### PR DESCRIPTION
Since the text is being lower()'d, it would be impossible to hit
an uppercase regex name.