### PR TITLE
Add GroupMe response delay

### DIFF
--- a/c3po/provider/groupme/receive.py
+++ b/c3po/provider/groupme/receive.py
@@ -2,6 +2,7 @@
 
 import logging
 import json
+import time
 
 import flask
 
@@ -16,6 +17,8 @@ SUCCESS = ('', 200)
 @APP.route('/groupme', methods=['POST'])
 def receive_message():
     """Processes a message and returns a response."""
+    time.sleep(.1)
+
     msg_data = json.loads(flask.request.data)
     group_id = msg_data['group_id']
     name = msg_data['name']


### PR DESCRIPTION
GroupMe has a bug where the bot response will appear in the timeline
ahead of the message that actually caused it. Because of this,
adding a .1 second delay to all web requests to make sure this
doesn't happen.