### PR TITLE
Fix typo

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -1,4 +1,4 @@
-zcron:
+cron:
 - description: prayer request reminders
   url: /cron/prayer
   schedule: every day 08:30


### PR DESCRIPTION
Somehow cron got turned to zcron and wasn't caught in code review.
Fixing so that deployment actually succeeds.