### PR TITLE
Add rate limiting capability

### DIFF
--- a/c3po/message.py
+++ b/c3po/message.py
@@ -73,7 +73,8 @@ class Message(object):
 
         self.text_chunks = re.split(regex, self.text)
         response = responder(self)
-        self.send_message(response)
+        if response:
+            self.send_message(response)
 
     @abc.abstractmethod
     def send_message(self, response):

--- a/c3po/response_mgr/base.py
+++ b/c3po/response_mgr/base.py
@@ -1,12 +1,32 @@
 """Contains the definitions for the responders."""
-import random
-import json
 
+from datetime import datetime
+from datetime import timedelta
+import json
+import logging
+import random
+
+from google.appengine.api import memcache
 from google.appengine.api import urlfetch
 
 from c3po import text_chunks
 
+DATE_FORMAT = "%Y-%m-%d %H:%M:%S.%f"
 FORECAST_API_ENDPOINT = "https://api.forecast.io/forecast/%s/%s,%s?units=auto"
+
+
+def rate_limit(memcache_key, minutes=30):
+    """Rate limits a function by a number of minutes."""
+    last_use = memcache.get(memcache_key)
+    if last_use:
+        delta = datetime.now() - datetime.strptime(last_use, DATE_FORMAT)
+        min_delta = timedelta(minutes=minutes)
+        if delta < min_delta:
+            logging.info("Rate Limit: not sending a response.")
+            return True
+
+    memcache.set(memcache_key, datetime.now().strftime(DATE_FORMAT))
+    return False
 
 
 class BaseResponseManager(object):

--- a/c3po/response_mgr/small_group.py
+++ b/c3po/response_mgr/small_group.py
@@ -84,6 +84,9 @@ class SmallGroupResponseManager(base.BaseResponseManager):
     @staticmethod
     def clark(_msg):
         """Clark it up."""
+        if base.rate_limit('clark'):
+            return
+
         if is_clark_closed():
             return "Uh oh! Clark is closed right now."
 

--- a/tests/response_mgr/test_small_group.py
+++ b/tests/response_mgr/test_small_group.py
@@ -82,13 +82,16 @@ class TestSmallGroupResponders(unittest.TestCase):
 
         self.mock_send.assert_called_with('Got it.')
 
+    @mock.patch('c3po.response_mgr.base.rate_limit')
     @mock.patch('c3po.response_mgr.small_group.get_clark_menu_items')
     @mock.patch('c3po.response_mgr.small_group.get_current_meal')
     @mock.patch('c3po.response_mgr.small_group.is_clark_closed')
-    def test_clark(self, fake_clark_closed, fake_current_meal, fake_clark_menu):
+    def test_clark(self, fake_clark_closed, fake_current_meal, fake_clark_menu,
+                   fake_rate_limit):
         fake_clark_closed.return_value = False
         fake_current_meal.return_value = 'dinner'
         fake_clark_menu.return_value = json.loads(fakes.CLARK_MENU)
+        fake_rate_limit.return_value = False
 
         self.msg.text = 'clark?'
         self.msg.process_message()


### PR DESCRIPTION
Some responses shouldn't be repeated more than once for a period
of time.  For now, we're enabling this rate limiting on the
ClarkAlert responder.

Fixes #73