### PR TITLE
Update Clark Regex

### DIFF
--- a/c3po/persona/small_group.py
+++ b/c3po/persona/small_group.py
@@ -68,7 +68,7 @@ class SmallGroupPersona(base.BasePersona):
 
         self.not_mentioned_map.update({
             r'(^)pr (.+)': self.add_prayer_request,
-            r'clark\?': self.clark,
+            r'clark(|.+)\?': self.clark,
         })
 
     @staticmethod

--- a/tests/persona/test_small_group.py
+++ b/tests/persona/test_small_group.py
@@ -93,7 +93,7 @@ class TestSmallGroupResponders(unittest.TestCase):
         fake_clark_menu.return_value = json.loads(fakes.CLARK_MENU)
         fake_rate_limit.return_value = False
 
-        self.msg.text = 'clark?'
+        self.msg.text = 'clark anyone?'
         self.msg.process_message()
 
         response = "ClarkAlert for dinner: Chicken."


### PR DESCRIPTION
If there is the word 'clark' and a '?' anywhere else in the string,
trigger the ClarkAlert. 'clark?' is not a very common saying, so
it isn't triggered often.  Combined with the recent rate-limiting
patch, this should be a good solution.