### PR TITLE
Add ability to customize bot name

### DIFF
--- a/c3po/db/settings.py
+++ b/c3po/db/settings.py
@@ -22,6 +22,9 @@ class Settings(ndb.Model):
     """Models the mapping between group ID and bot ID."""
     provider_name = ndb.StringProperty(required=True)
     persona_name = ndb.StringProperty(required=True)
+    bot_name = ndb.StringProperty(required=True, default='C-3PO')
+    bot_mentioned_regex = ndb.StringProperty(required=True,
+                                             default='(c-3po|c3po)')
 
     groupme_conf = ndb.StructuredProperty(groupme_conf.GroupmeConf)
     prayer_requests = ndb.StructuredProperty(prayer_request.PrayerRequest,

--- a/c3po/message.py
+++ b/c3po/message.py
@@ -4,8 +4,6 @@ import abc
 import logging
 import re
 
-REGEX_MENTIONED = r'(c-3po|c3po)'
-
 # Regex matching either:
 #   1) beginning of string
 #   2) one or many whitespace chars
@@ -57,7 +55,7 @@ class Message(object):
     def process_message(self):
         """Finds the responder and uses it to send a response."""
         regex, responder = None, None
-        if re.search(REGEX_MENTIONED, self.text.lower()):
+        if re.search(self.settings.bot_mentioned_regex, self.text.lower()):
             # Check for matches where C-3PO is mentioned
             regex, responder = self._get_responder(
                 self.persona.mentioned_map)

--- a/c3po/provider/groupme/receive.py
+++ b/c3po/provider/groupme/receive.py
@@ -31,11 +31,12 @@ def receive_message():
     logging.info("Name: %s", name)
     logging.info("Text: %s", text)
 
-    if name == 'C-3PO':
+    msg = send.GroupmeMessage(group_id, name, text)
+
+    if name == msg.settings.bot_name:
         logging.info("Ignoring request since it's coming from the bot.")
         return SUCCESS
 
-    msg = send.GroupmeMessage(group_id, name, text)
     msg.process_message()
 
     return SUCCESS

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -59,6 +59,9 @@ class FakeBaseSettings(mock.Mock):
         self.groupme_conf = mock.Mock()
         self.groupme_conf.bot_id = BOT_ID
 
+        self.bot_name = 'C-3PO'
+        self.bot_mentioned_regex = '(c-3po|c3po)'
+
         self.weather_conf = mock.Mock()
         self.weather_conf.api_key = '1234'
         self.weather_conf.latitude = '35.7806'


### PR DESCRIPTION
If you want to make a bot name different than C-3PO, you should
be able to. This involves customizing the official bot name coming
from the provider (to make sure it doesn't respond to itself) and
the 'mentioned' criteria (what others use to call attention to the
bot).

Fix #69