### PR TITLE
Multiple Bots in One Room

### DIFF
--- a/app.yaml
+++ b/app.yaml
@@ -5,7 +5,7 @@ api_version: 1
 threadsafe: yes
 
 handlers:
-- url: /groupme
+- url: /groupme/.*
   script: c3po.provider.groupme.receive.APP
 
 - url: /admin/.*

--- a/c3po/cron.py
+++ b/c3po/cron.py
@@ -16,7 +16,7 @@ TEXT_LIMIT = 30
 def create_message(settings_obj):
     """Creates a message object to use for sending."""
     if settings_obj.provider_name == 'groupme':
-        return groupme_send.GroupmeMessage(settings_obj.groupme_conf.group_id,
+        return groupme_send.GroupmeMessage(settings_obj.bot_id,
                                            None, None)
 
 

--- a/c3po/db/settings.py
+++ b/c3po/db/settings.py
@@ -22,6 +22,12 @@ class Settings(ndb.Model):
     """Models the mapping between group ID and bot ID."""
     provider_name = ndb.StringProperty(required=True)
     persona_name = ndb.StringProperty(required=True)
+
+    # Arbitrary identifier to be included in every callback URL to identify
+    # which bot the callback is for. NOT associated with any particular
+    # provider.
+    bot_id = ndb.StringProperty(required=True)
+
     bot_name = ndb.StringProperty(required=True, default='C-3PO')
     bot_mentioned_regex = ndb.StringProperty(required=True,
                                              default='(c-3po|c3po)')

--- a/c3po/message.py
+++ b/c3po/message.py
@@ -33,8 +33,8 @@ class Message(object):
         self.text_chunks = None
 
     @abc.abstractmethod
-    def _get_settings(self, group_id):
-        """Finds the Settings object associated with group_id."""
+    def _get_settings(self, bot_id):
+        """Finds the Settings object associated with bot_id."""
         return
 
     def _get_responder(self, responder_map):

--- a/c3po/provider/groupme/receive.py
+++ b/c3po/provider/groupme/receive.py
@@ -14,8 +14,8 @@ APP.config['DEBUG'] = True
 SUCCESS = ('', 200)
 
 
-@APP.route('/groupme', methods=['POST'])
-def receive_message():
+@APP.route('/groupme/<bot_id>', methods=['POST'])
+def receive_message(bot_id):
     """Processes a message and returns a response."""
     time.sleep(.1)
 
@@ -24,14 +24,14 @@ def receive_message():
     name = msg_data['name']
     text = msg_data['text']
 
-    if not group_id or not name or not text:
+    if not bot_id or not group_id or not name or not text:
         flask.abort(400)
 
     logging.info("Group ID: %s", group_id)
     logging.info("Name: %s", name)
     logging.info("Text: %s", text)
 
-    msg = send.GroupmeMessage(group_id, name, text)
+    msg = send.GroupmeMessage(bot_id, name, text)
 
     if name == msg.settings.bot_name:
         logging.info("Ignoring request since it's coming from the bot.")

--- a/c3po/provider/groupme/send.py
+++ b/c3po/provider/groupme/send.py
@@ -17,26 +17,26 @@ GROUPME_API_FULL = "%s%s" % (GROUPME_API_ENDPOINT, GROUPME_API_PATH)
 class GroupmeMessage(message.Message):
     """Implements Message for the GroupMe provider."""
 
-    def __init__(self, group_id, name, text):
+    def __init__(self, bot_id, name, text):
         super(GroupmeMessage, self).__init__(name, text)
 
-        self.settings = self._get_settings(group_id)
-        self.bot_id = self.settings.groupme_conf.bot_id
+        self.settings = self._get_settings(bot_id)
+        self.groupme_bot_id = self.settings.groupme_conf.bot_id
         self.persona = self.settings.get_persona()
 
-    def _get_settings(self, group_id):
+    def _get_settings(self, bot_id):
         """Finds the Settings object associated with group_id."""
         results = settings.Settings.query(
-            settings.Settings.groupme_conf.group_id == group_id)
+            settings.Settings.bot_id == bot_id)
 
         if results.count() <= 0:
             raise ValueError(
-                "No Settings objects found matching group_id: %s. "
-                "Cannot continue." % group_id)
+                "No Settings objects found matching bot_id: %s. "
+                "Cannot continue." % bot_id)
         elif results.count() > 1:
             raise RuntimeError(
-                "Found multiple Settings objects with group_id: %s. "
-                "Cannot continue." % group_id)
+                "Found multiple Settings objects with bot_id: %s. "
+                "Cannot continue." % bot_id)
 
         msg_settings = results.fetch(1)[0]
         self._validate_settings(msg_settings)
@@ -45,7 +45,7 @@ class GroupmeMessage(message.Message):
     def _generate_api_post_body(self, response):
         """Generates the request body to be sent"""
         body = {
-            'bot_id': self.bot_id,
+            'bot_id': self.groupme_bot_id,
             'text': response
         }
 
@@ -54,7 +54,7 @@ class GroupmeMessage(message.Message):
     def send_message(self, response):
         """Sends the given response to the API."""
         logging.info("Sending this response: '%s' to bot_id: '%s'",
-                     response, self.bot_id)
+                     response, self.groupme_bot_id)
 
         post_body = self._generate_api_post_body(response)
         result = urlfetch.fetch(url=GROUPME_API_FULL,

--- a/tests/fakes.py
+++ b/tests/fakes.py
@@ -6,7 +6,6 @@ from c3po.persona import eastside
 from c3po.persona import small_group
 
 BOT_ID = '123'
-GROUP_ID = 'abc'
 NAME = 'Billy'
 TEXT = ''
 CLARK_CLOSED = """

--- a/tests/persona/test_base.py
+++ b/tests/persona/test_base.py
@@ -19,7 +19,7 @@ class TestBaseResponders(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBaseSettings()
 
-        self.msg = send.GroupmeMessage(fakes.GROUP_ID, fakes.NAME, '')
+        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME, '')
 
     def test_creator(self):
         self.msg.text = 'c3po who created you?'

--- a/tests/persona/test_beasts.py
+++ b/tests/persona/test_beasts.py
@@ -19,7 +19,7 @@ class TestBeastsResponders(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBeastsSettings()
 
-        self.msg = send.GroupmeMessage(fakes.GROUP_ID, fakes.NAME, '')
+        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME, '')
 
     @mock.patch('c3po.persona.base.rate_limit')
     def test_babe_wait(self, mock_rate):

--- a/tests/persona/test_eastside.py
+++ b/tests/persona/test_eastside.py
@@ -19,7 +19,7 @@ class TestEastsideResponders(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeEastsideSettings()
 
-        self.msg = send.GroupmeMessage(fakes.GROUP_ID, fakes.NAME, '')
+        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME, '')
 
     def test_negative(self):
         self.msg.text = 'this is only a test'

--- a/tests/persona/test_small_group.py
+++ b/tests/persona/test_small_group.py
@@ -71,7 +71,7 @@ class TestSmallGroupResponders(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeSmallGroupSettings()
 
-        self.msg = send.GroupmeMessage(fakes.GROUP_ID, fakes.NAME, '')
+        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME, '')
 
     @mock.patch('random.choice')
     def test_add_prayer_request(self, mock_random):

--- a/tests/provider/test_groupme.py
+++ b/tests/provider/test_groupme.py
@@ -19,7 +19,7 @@ class TestGeneratePostBody(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBaseResponseMgr()
 
-        self.msg = message.Message(fakes.GROUP_ID, fakes.NAME, fakes.TEXT)
+        self.msg = message.Message(fakes.BOT_ID, fakes.NAME, fakes.TEXT)
 
     def test_generate_api_post_body(self):
         actual_post_body = self.msg.provider._generate_api_post_body('sample')
@@ -35,7 +35,7 @@ class TestSendResponse(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBaseResponseMgr()
 
-        self.msg = message.Message(fakes.GROUP_ID, fakes.NAME, fakes.TEXT)
+        self.msg = message.Message(fakes.BOT_ID, fakes.NAME, fakes.TEXT)
 
     @mock.patch('c3po.message.Message._generate_api_post_body')
     @mock.patch('google.appengine.api.urlfetch.fetch')


### PR DESCRIPTION
Adding the bot ID to the callback URL so we can identify which
callback belongs to which bot instead of having it as a 1:1
bot:group mapping.

Fixes #78