### PR TITLE
Use Generic Message for Tests

### DIFF
--- a/c3po/tests/fakes.py
+++ b/c3po/tests/fakes.py
@@ -1,5 +1,6 @@
 import mock
 
+from c3po import message
 from c3po.persona import base
 from c3po.persona import beasts
 from c3po.persona import eastside
@@ -50,6 +51,21 @@ WEATHER_JSON = """
    }
 }
 """
+
+
+class FakeMessage(message.Message):
+    def __init__(self, name, text):
+        super(FakeMessage, self).__init__(name, text)
+        self.settings = self._get_settings(BOT_ID)
+        self.persona = self.settings.get_persona()
+
+    def _get_settings(self, bot_id):
+        # This is mocked out in tests
+        return FakeBaseSettings()
+
+    def send_message(self, response):
+        # This is mocked out in tests
+        pass
 
 
 class FakeBaseSettings(mock.Mock):

--- a/c3po/tests/persona/test_base.py
+++ b/c3po/tests/persona/test_base.py
@@ -2,24 +2,23 @@ import unittest
 
 import mock
 
-from c3po.provider.groupme import send
 from c3po.tests import fakes
 
 
 class TestBaseResponders(unittest.TestCase):
     def setUp(self):
         send_patcher = mock.patch(
-            'c3po.provider.groupme.send.GroupmeMessage.send_message')
+            'c3po.tests.fakes.FakeMessage.send_message')
         self.addCleanup(send_patcher.stop)
         self.mock_send = send_patcher.start()
 
         settings_patcher = mock.patch(
-            'c3po.provider.groupme.send.GroupmeMessage._get_settings')
+            'c3po.tests.fakes.FakeMessage._get_settings')
         self.addCleanup(settings_patcher.stop)
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBaseSettings()
 
-        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME, '')
+        self.msg = fakes.FakeMessage(fakes.NAME, '')
 
     def test_creator(self):
         self.msg.text = 'c3po who created you?'

--- a/c3po/tests/persona/test_beasts.py
+++ b/c3po/tests/persona/test_beasts.py
@@ -2,24 +2,23 @@ import unittest
 
 import mock
 
-from c3po.provider.groupme import send
 from c3po.tests import fakes
 
 
 class TestBeastsResponders(unittest.TestCase):
     def setUp(self):
         send_patcher = mock.patch(
-            'c3po.provider.groupme.send.GroupmeMessage.send_message')
+            'c3po.tests.fakes.FakeMessage.send_message')
         self.addCleanup(send_patcher.stop)
         self.mock_send = send_patcher.start()
 
         settings_patcher = mock.patch(
-            'c3po.provider.groupme.send.GroupmeMessage._get_settings')
+            'c3po.tests.fakes.FakeMessage._get_settings')
         self.addCleanup(settings_patcher.stop)
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBeastsSettings()
 
-        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME, '')
+        self.msg = fakes.FakeMessage(fakes.NAME, '')
 
     @mock.patch('c3po.persona.base.rate_limit')
     def test_babe_wait(self, mock_rate):

--- a/c3po/tests/persona/test_eastside.py
+++ b/c3po/tests/persona/test_eastside.py
@@ -2,24 +2,23 @@ import unittest
 
 import mock
 
-from c3po.provider.groupme import send
 from c3po.tests import fakes
 
 
 class TestEastsideResponders(unittest.TestCase):
     def setUp(self):
         send_patcher = mock.patch(
-            'c3po.provider.groupme.send.GroupmeMessage.send_message')
+            'c3po.tests.fakes.FakeMessage.send_message')
         self.addCleanup(send_patcher.stop)
         self.mock_send = send_patcher.start()
 
         settings_patcher = mock.patch(
-            'c3po.provider.groupme.send.GroupmeMessage._get_settings')
+            'c3po.tests.fakes.FakeMessage._get_settings')
         self.addCleanup(settings_patcher.stop)
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeEastsideSettings()
 
-        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME, '')
+        self.msg = fakes.FakeMessage(fakes.NAME, '')
 
     def test_negative(self):
         self.msg.text = 'this is only a test'

--- a/c3po/tests/persona/test_small_group.py
+++ b/c3po/tests/persona/test_small_group.py
@@ -4,7 +4,6 @@ import unittest
 import freezegun
 import mock
 
-from c3po.provider.groupme import send
 from c3po.tests import fakes
 from c3po.persona import small_group
 
@@ -61,17 +60,17 @@ class TestClarkClosed(unittest.TestCase):
 class TestSmallGroupResponders(unittest.TestCase):
     def setUp(self):
         send_patcher = mock.patch(
-            'c3po.provider.groupme.send.GroupmeMessage.send_message')
+            'c3po.tests.fakes.FakeMessage.send_message')
         self.addCleanup(send_patcher.stop)
         self.mock_send = send_patcher.start()
 
         settings_patcher = mock.patch(
-            'c3po.provider.groupme.send.GroupmeMessage._get_settings')
+            'c3po.tests.fakes.FakeMessage._get_settings')
         self.addCleanup(settings_patcher.stop)
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeSmallGroupSettings()
 
-        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME, '')
+        self.msg = fakes.FakeMessage(fakes.NAME, '')
 
     @mock.patch('random.choice')
     def test_add_prayer_request(self, mock_random):


### PR DESCRIPTION
Don't use the GroupMe specific message for test. Instead, test
against the abstract generic version and mock out what's needed.

Fixes #81