### PR TITLE
Mention the person when responding

### DIFF
--- a/c3po/message.py
+++ b/c3po/message.py
@@ -33,6 +33,11 @@ class Message(object):
         self.text_chunks = None
 
     @abc.abstractmethod
+    def _add_mention(self, response):
+        """When responding back to a person, mention them."""
+        return
+
+    @abc.abstractmethod
     def _get_settings(self, bot_id):
         """Finds the Settings object associated with bot_id."""
         return
@@ -72,6 +77,7 @@ class Message(object):
         self.text_chunks = re.split(regex, self.text)
         response = responder(self)
         if response:
+            response = self._add_mention(response)
             self.send_message(response)
 
     @abc.abstractmethod

--- a/c3po/provider/groupme/send.py
+++ b/c3po/provider/groupme/send.py
@@ -22,7 +22,13 @@ class GroupmeMessage(message.Message):
 
         self.settings = self._get_settings(bot_id)
         self.groupme_bot_id = self.settings.groupme_conf.bot_id
+        self.name = name
         self.persona = self.settings.get_persona()
+
+    def _add_mention(self, response):
+        """When responding back to a person, mention them."""
+        if self.name:
+            return "@%s: %s" % (self.name, response)
 
     def _get_settings(self, bot_id):
         """Finds the Settings object associated with group_id."""

--- a/c3po/tests/fakes.py
+++ b/c3po/tests/fakes.py
@@ -59,6 +59,10 @@ class FakeMessage(message.Message):
         self.settings = self._get_settings(BOT_ID)
         self.persona = self.settings.get_persona()
 
+    def _add_mention(self, response):
+        # This is mocked out in tests
+        return response
+
     def _get_settings(self, bot_id):
         # This is mocked out in tests
         return FakeBaseSettings()

--- a/c3po/tests/persona/test_base.py
+++ b/c3po/tests/persona/test_base.py
@@ -5,6 +5,31 @@ import mock
 from c3po.tests import fakes
 
 
+class TestAddMention(unittest.TestCase):
+    def setUp(self):
+        send_patcher = mock.patch(
+            'c3po.tests.fakes.FakeMessage.send_message')
+        self.addCleanup(send_patcher.stop)
+        self.mock_send = send_patcher.start()
+
+        settings_patcher = mock.patch(
+            'c3po.tests.fakes.FakeMessage._get_settings')
+        self.addCleanup(settings_patcher.stop)
+        self.mock_settings = settings_patcher.start()
+        self.mock_settings.return_value = fakes.FakeBaseSettings()
+
+        self.msg = fakes.FakeMessage(fakes.NAME, '')
+
+    @mock.patch('c3po.tests.fakes.FakeMessage._add_mention')
+    def test_add_mention(self, fake_add_mention):
+        fake_add_mention.return_value = "%s: %s" % (fakes.NAME, 'pong')
+
+        self.msg.text = 'c3po ping'
+        self.msg.process_message()
+
+        self.mock_send.assert_called_with('Billy: pong')
+
+
 class TestBaseResponders(unittest.TestCase):
     def setUp(self):
         send_patcher = mock.patch(


### PR DESCRIPTION
When responding to a person, @ their name to signify who C-3PO is talking to. IRC bots do this.

Fixes #94