### PR TITLE
Use attachments to extract picture_url

### DIFF
--- a/c3po/cron.py
+++ b/c3po/cron.py
@@ -16,7 +16,8 @@ TEXT_LIMIT = 30
 def create_message(settings_obj):
     """Creates a message object to use for sending."""
     if settings_obj.provider_name == 'groupme':
-        return groupme_send.GroupmeMessage(settings_obj.bot_id, None)
+        return groupme_send.GroupmeMessage(settings_obj.bot_id, None, None,
+                                           None, None)
 
 
 @APP.route('/cron/prayer')

--- a/c3po/provider/groupme/receive.py
+++ b/c3po/provider/groupme/receive.py
@@ -19,11 +19,19 @@ def receive_message(bot_id):
     """Processes a message and returns a response."""
     time.sleep(.1)
 
+    logging.info("Request data: %s", flask.request.data)
+
     msg_data = json.loads(flask.request.data)
     group_id = msg_data['group_id']
     name = msg_data['name']
-    picture_url = msg_data['picture_url']
     text = msg_data['text']
+    time_sent = float(msg_data['created_at'])
+
+    picture_url = None
+    attachments = msg_data['attachments']
+    if attachments:
+        if attachments[0]['type'] == 'image':
+            picture_url = attachments[0]['url']
 
     if not bot_id or not group_id or not name or (not text and not picture_url):
         flask.abort(400)
@@ -32,7 +40,7 @@ def receive_message(bot_id):
     logging.info("Name: %s", name)
     logging.info("Text: %s", text)
 
-    msg = send.GroupmeMessage(bot_id, msg_data)
+    msg = send.GroupmeMessage(bot_id, name, picture_url, text, time_sent)
 
     if name == msg.settings.bot_name:
         logging.info("Ignoring request since it's coming from the bot.")

--- a/c3po/provider/groupme/send.py
+++ b/c3po/provider/groupme/send.py
@@ -17,12 +17,7 @@ GROUPME_API_FULL = "%s%s" % (GROUPME_API_ENDPOINT, GROUPME_API_PATH)
 class GroupmeMessage(message.Message):
     """Implements Message for the GroupMe provider."""
 
-    def __init__(self, bot_id, msg_data):
-        name = msg_data['name']
-        picture_url = msg_data['picture_url']
-        text = msg_data['text']
-        time_sent = float(msg_data['created_at'])
-
+    def __init__(self, bot_id, name, picture_url, text, time_sent):   # pylint: disable=too-many-arguments
         super(GroupmeMessage, self).__init__(name, picture_url, text, time_sent)
 
         self.settings = self._get_settings(bot_id)

--- a/c3po/tests/fakes.py
+++ b/c3po/tests/fakes.py
@@ -12,12 +12,6 @@ NAME = 'Billy'
 PICTURE_URL = 'https://example.com/image.jpg'
 TEXT = ''
 TIME_SENT = 1442722989
-MSG_DATA = {
-    'name': NAME,
-    'picture_url': PICTURE_URL,
-    'text': TEXT,
-    'created_at': TIME_SENT
-}
 CLARK_CLOSED = """
 {
     "Remote":{

--- a/c3po/tests/provider/test_groupme.py
+++ b/c3po/tests/provider/test_groupme.py
@@ -19,7 +19,9 @@ class TestGeneratePostBody(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBaseSettings()
 
-        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.MSG_DATA)
+        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME,
+                                       fakes.PICTURE_URL, fakes.TEXT,
+                                       fakes.TIME_SENT)
 
     def test_generate_api_post_body(self):
         actual_post_body = self.msg._generate_api_post_body('sample')
@@ -35,7 +37,9 @@ class TestSendResponse(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBaseSettings()
 
-        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.MSG_DATA)
+        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME,
+                                       fakes.PICTURE_URL, fakes.TEXT,
+                                       fakes.TIME_SENT)
 
     @mock.patch('c3po.provider.groupme.send.GroupmeMessage._generate_api_post_body')
     @mock.patch('google.appengine.api.urlfetch.fetch')


### PR DESCRIPTION
The production GroupMe calls use an attachment object with images
embedded inside of it. Adapted the code to use that instead of the
documented 'picture_url' syntax.
