### PR TITLE
Throwback | if picture, send correctly

### DIFF
--- a/c3po/message.py
+++ b/c3po/message.py
@@ -26,6 +26,8 @@ class Message(object):
     response. Overridden and extended by a provider to get provider-specific
     send logic."""
 
+    # pylint: disable=too-many-instance-attributes
+
     __metaclass__ = abc.ABCMeta
 
     def __init__(self, name, picture_url, text, time_sent):
@@ -37,6 +39,8 @@ class Message(object):
         self.text = text
         self.text_chunks = None
         self.time_sent = time_sent
+
+        self.picture_url_to_send = None
 
     @abc.abstractmethod
     def _add_mention(self, response):

--- a/c3po/persona/base.py
+++ b/c3po/persona/base.py
@@ -113,6 +113,11 @@ class BasePersona(object):
                                      limit=1)[0]
         time_sent = random_msg.time_sent.strftime('%m/%d/%Y')
 
+        if random_msg.picture_url:
+            msg.picture_url_to_send = random_msg.picture_url
+            return 'Throwback! On %s, %s posted this photo.' % (
+                time_sent, random_msg.name)
+
         return 'Throwback! On %s, %s said, "%s".' % (
             time_sent, random_msg.name, random_msg.text)
 

--- a/c3po/tests/fakes.py
+++ b/c3po/tests/fakes.py
@@ -96,7 +96,7 @@ class FakeStoredMessage(mock.Mock):
         super(FakeStoredMessage, self).__init__()
 
         self.name = NAME
-        self.picture_url = PICTURE_URL
+        self.picture_url = None
         self.response_triggered = False
         self.text = TEXT
         self.time_sent = datetime.fromtimestamp(TIME_SENT)
@@ -114,6 +114,17 @@ class FakeNDBQuery(mock.Mock):
     @staticmethod
     def fetch(**_):
         return [FakeStoredMessage()]
+
+
+class FakeNDBQueryPicture(FakeNDBQuery):
+    def __init__(self):
+        super(FakeNDBQueryPicture, self).__init__()
+
+    @staticmethod
+    def fetch(**_):
+        fake_msg = FakeStoredMessage()
+        fake_msg.picture_url = PICTURE_URL
+        return [fake_msg]
 
 
 class FakeBaseSettings(mock.Mock):

--- a/c3po/tests/persona/test_base.py
+++ b/c3po/tests/persona/test_base.py
@@ -104,7 +104,7 @@ class TestBaseResponders(unittest.TestCase):
             "You're welcome!")
 
     @mock.patch('c3po.db.stored_message.StoredMessage.query')
-    def test_throwback(self, mock_query):
+    def test_throwback_no_picture(self, mock_query):
         mock_query.return_value = fakes.FakeNDBQuery()
 
         self.msg.text = 'c3po throwback'
@@ -112,6 +112,16 @@ class TestBaseResponders(unittest.TestCase):
 
         self.mock_send.assert_called_with(
             'Throwback! On 09/20/2015, Billy said, "hi".')
+
+    @mock.patch('c3po.db.stored_message.StoredMessage.query')
+    def test_throwback_picture(self, mock_query):
+        mock_query.return_value = fakes.FakeNDBQueryPicture()
+
+        self.msg.text = 'c3po throwback'
+        self.msg.process_message()
+
+        self.mock_send.assert_called_with(
+            'Throwback! On 09/20/2015, Billy posted this photo.')
 
     @mock.patch('google.appengine.api.urlfetch.fetch')
     def test_weather(self, mock_fetch):

--- a/c3po/tests/provider/test_groupme.py
+++ b/c3po/tests/provider/test_groupme.py
@@ -7,7 +7,6 @@ from c3po.provider.groupme import send
 from c3po.tests import fakes
 
 GROUPME_API_ENDPOINT = 'https://api.groupme.com'
-GROUPME_API_HEADERS = {'Content-Type': 'application/x-www-form-urlencoded'}
 GROUPME_API_PATH = '/v3/bots/post'
 GROUPME_API_FULL = "%s%s" % (GROUPME_API_ENDPOINT, GROUPME_API_PATH)
 
@@ -25,7 +24,7 @@ class TestGeneratePostBody(unittest.TestCase):
 
     def test_generate_api_post_body(self):
         actual_post_body = self.msg._generate_api_post_body('sample')
-        expected_post_body = 'text=sample&bot_id=123'
+        expected_post_body = '{"text": "sample", "bot_id": "123"}'
 
         self.assertEqual(actual_post_body, expected_post_body)
 
@@ -44,22 +43,21 @@ class TestSendResponse(unittest.TestCase):
     @mock.patch('c3po.provider.groupme.send.GroupmeMessage._generate_api_post_body')
     @mock.patch('google.appengine.api.urlfetch.fetch')
     def test_send_response(self, mock_urlfetch, mock_gen_api_post_body):
-        mock_gen_api_post_body.return_value = 'text=sample&bot_id=123'
+        mock_gen_api_post_body.return_value = '{"text": "sample", "bot_id": "123"}'
         mock_urlfetch.return_value.status_code = 202
 
         self.msg.send_message('sample')
 
         mock_urlfetch.assert_called_with(
             url=GROUPME_API_ENDPOINT + GROUPME_API_PATH,
-            payload='text=sample&bot_id=123',
-            method=urlfetch.POST,
-            headers=GROUPME_API_HEADERS
+            payload='{"text": "sample", "bot_id": "123"}',
+            method=urlfetch.POST
         )
 
     @mock.patch('c3po.provider.groupme.send.GroupmeMessage._generate_api_post_body')
     @mock.patch('google.appengine.api.urlfetch.fetch')
     def test_send_response_500(self, mock_urlfetch, mock_gen_api_post_body):
-        mock_gen_api_post_body.return_value = 'text=sample&bot_id=123'
+        mock_gen_api_post_body.return_value = '{"text": "sample", "bot_id": "123"}'
         mock_urlfetch.return_value.status_code = 202
 
         self.msg.send_message('sample')


### PR DESCRIPTION
Currently the throwback only supports sending back text. If picture_url
is present, figure out how to send that instead. Related to #57 .

Closes #118