### PR TITLE
Optimize throwback performance

### DIFF
--- a/c3po/persona/base.py
+++ b/c3po/persona/base.py
@@ -110,7 +110,8 @@ class BasePersona(object):
             stored_message.StoredMessage.settings == msg.settings.key)
         msg_count = msg_query.count()
         random_msg = msg_query.fetch(offset=random.randrange(0, msg_count),
-                                     limit=1)[0]
+                                     limit=1,
+                                     keys_only=True)[0].get()
         time_sent = random_msg.time_sent.strftime('%m/%d/%Y')
 
         if random_msg.picture_url:

--- a/c3po/tests/fakes.py
+++ b/c3po/tests/fakes.py
@@ -1,8 +1,6 @@
 from datetime import datetime
 import mock
-
 from google.appengine.ext import ndb
-
 from c3po import message
 from c3po.db import settings
 from c3po.persona import base
@@ -103,28 +101,29 @@ class FakeStoredMessage(mock.Mock):
         self.settings = FakeBaseSettings()
 
 
+class FakeStoredMessageKey(mock.Mock):
+    def __init__(self, picture):
+        super(FakeStoredMessageKey, self).__init__()
+        self.picture = picture
+
+    def get(self):
+        fake_msg = FakeStoredMessage()
+        if self.picture:
+            fake_msg.picture_url = PICTURE_URL
+        return fake_msg
+
+
 class FakeNDBQuery(mock.Mock):
-    def __init__(self):
+    def __init__(self, picture=False):
         super(FakeNDBQuery, self).__init__()
+        self.picture = picture
 
     @staticmethod
     def count():
         return 5
 
-    @staticmethod
-    def fetch(**_):
-        return [FakeStoredMessage()]
-
-
-class FakeNDBQueryPicture(FakeNDBQuery):
-    def __init__(self):
-        super(FakeNDBQueryPicture, self).__init__()
-
-    @staticmethod
-    def fetch(**_):
-        fake_msg = FakeStoredMessage()
-        fake_msg.picture_url = PICTURE_URL
-        return [fake_msg]
+    def fetch(self, **_):
+        return [FakeStoredMessageKey(self.picture)]
 
 
 class FakeBaseSettings(mock.Mock):

--- a/c3po/tests/persona/test_base.py
+++ b/c3po/tests/persona/test_base.py
@@ -115,7 +115,7 @@ class TestBaseResponders(unittest.TestCase):
 
     @mock.patch('c3po.db.stored_message.StoredMessage.query')
     def test_throwback_picture(self, mock_query):
-        mock_query.return_value = fakes.FakeNDBQueryPicture()
+        mock_query.return_value = fakes.FakeNDBQuery(picture=True)
 
         self.msg.text = 'c3po throwback'
         self.msg.process_message()


### PR DESCRIPTION
Run a keys_only query to speed up access times. There is still
probably a better way to solve this problem, but this is a good
stopgap until that happens.

Fixes #122