### PR TITLE
Ensure that all requests take at least .4 seconds

### DIFF
--- a/c3po/cron.py
+++ b/c3po/cron.py
@@ -14,5 +14,5 @@ TEXT_LIMIT = 30
 def create_message(settings_obj):
     """Creates a fake message object in which you can call .send_message()."""
     if settings_obj.provider_name == 'groupme':
-        return groupme_send.GroupmeMessage(settings_obj.bot_id, None, None,
-                                           None, None)
+        return groupme_send.GroupmeMessage(None, settings_obj.bot_id, None,
+                                           None, None, None)

--- a/c3po/provider/groupme/receive.py
+++ b/c3po/provider/groupme/receive.py
@@ -17,6 +17,7 @@ SUCCESS = ('', 200)
 @APP.route('/groupme/<bot_id>', methods=['POST'])
 def receive_message(bot_id):
     """Processes a message and returns a response."""
+    start_time = time.time()
 
     logging.info("Request data: %s", flask.request.data)
 
@@ -39,7 +40,8 @@ def receive_message(bot_id):
     logging.info("Name: %s", name)
     logging.info("Text: %s", text)
 
-    msg = send.GroupmeMessage(bot_id, name, picture_url, text, time_sent)
+    msg = send.GroupmeMessage(start_time, bot_id, name, picture_url, text,
+                              time_sent)
 
     if name == msg.settings.bot_name:
         logging.info("Ignoring request since it's coming from the bot.")

--- a/c3po/tests/provider/test_groupme.py
+++ b/c3po/tests/provider/test_groupme.py
@@ -6,6 +6,8 @@ from google.appengine.api import urlfetch
 from c3po.provider.groupme import send
 from c3po.tests import fakes
 
+FAKE_TIME_STARTED = 1448951940.077249
+
 GROUPME_API_ENDPOINT = 'https://api.groupme.com'
 GROUPME_API_PATH = '/v3/bots/post'
 GROUPME_API_FULL = "%s%s" % (GROUPME_API_ENDPOINT, GROUPME_API_PATH)
@@ -18,9 +20,9 @@ class TestGeneratePostBody(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBaseSettings()
 
-        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME,
-                                       fakes.PICTURE_URL, fakes.TEXT,
-                                       fakes.TIME_SENT)
+        self.msg = send.GroupmeMessage(FAKE_TIME_STARTED, fakes.BOT_ID,
+                                       fakes.NAME, fakes.PICTURE_URL,
+                                       fakes.TEXT, fakes.TIME_SENT)
 
     def test_generate_api_post_body(self):
         actual_post_body = self.msg._generate_api_post_body('sample')
@@ -36,9 +38,9 @@ class TestSendResponse(unittest.TestCase):
         self.mock_settings = settings_patcher.start()
         self.mock_settings.return_value = fakes.FakeBaseSettings()
 
-        self.msg = send.GroupmeMessage(fakes.BOT_ID, fakes.NAME,
-                                       fakes.PICTURE_URL, fakes.TEXT,
-                                       fakes.TIME_SENT)
+        self.msg = send.GroupmeMessage(FAKE_TIME_STARTED, fakes.BOT_ID,
+                                       fakes.NAME, fakes.PICTURE_URL,
+                                       fakes.TEXT, fakes.TIME_SENT)
 
     @mock.patch('c3po.provider.groupme.send.GroupmeMessage._generate_api_post_body')
     @mock.patch('google.appengine.api.urlfetch.fetch')


### PR DESCRIPTION
Add a conditional sleep that only triggers if the request will
take less than .4 seconds. This is the number that, through testing,
yielded the least amount of errors while still being acceptable.