### PR TITLE
Throwback | Don't include messages that generate a C-3PO response

### DIFF
--- a/c3po/persona/util.py
+++ b/c3po/persona/util.py
@@ -32,7 +32,8 @@ def random_message(msg):
     msg_query = stored_message.StoredMessage.query(
         ndb.AND(
             stored_message.StoredMessage.settings == msg.settings.key,
-            stored_message.StoredMessage.time_sent <= random_target_date
+            stored_message.StoredMessage.time_sent <= random_target_date,
+            stored_message.StoredMessage.response_triggered == False  # pylint: disable=singleton-comparison
         )
     ).order(-stored_message.StoredMessage.time_sent)
 

--- a/index.yaml
+++ b/index.yaml
@@ -12,8 +12,10 @@ indexes:
 
 - kind: StoredMessage
   properties:
+  - name: response_triggered
   - name: settings
   - name: time_sent
+    direction: desc
 
 - kind: StoredMessage
   properties:


### PR DESCRIPTION
It's more fun when you don't get a throwback asking C-3PO to do
something.

Fixes #135