### PR TITLE
Reduce verbosity of ClarkAlert

### DIFF
--- a/c3po/persona/small_group.py
+++ b/c3po/persona/small_group.py
@@ -139,7 +139,7 @@ class SmallGroupPersona(base.BasePersona):
 
         # Filter down some of the options
         entrees = [item['description'] for _, item in all_menu_items.items()
-                   if item['type'] not in ['Soup', 'Side']
+                   if item['type'] in ['Entree', 'Grill']
                    if 'pizza' not in item['description'].lower()]
 
         return "ClarkAlert for %s: %s." \


### PR DESCRIPTION
Instead of including everything that wasn't a soup or salad,
let's only include "Entree" and "Grill" items